### PR TITLE
Fix lazy loading

### DIFF
--- a/skeleton-carousel.html
+++ b/skeleton-carousel.html
@@ -575,7 +575,7 @@
         let i = 0;
         for (i; i < content.length; ++i) {
           const value = content[i].getAttribute('data-src');
-          content[i].setAttribute('src', value);
+          content[i].src = value;
           content[i].removeAttribute('data-src');
         }
       }


### PR DESCRIPTION
Set src property instead of attribute. Otherwise e.g. iron-image doesn't get notified if src changes.