### PR TITLE
Compute selectedItem

### DIFF
--- a/skeleton-carousel.html
+++ b/skeleton-carousel.html
@@ -381,6 +381,7 @@
             type: Object,
             notify: true,
             readOnly: true,
+            computed: '_computeSelectedItem(selected, _children)'
           },
           /**
            * The user is swiping
@@ -565,6 +566,17 @@
       }
 
       /**
+       * Computed the selected item
+       *
+       * @param {array} children
+       * @param {number} selected
+       * @private
+       */
+      _computeSelectedItem(selected, children) {
+        return children[selected];
+      }
+
+      /**
        * Children change observer
        *
        * @param {array} children
@@ -666,8 +678,6 @@
        */
       _selectedObserver(newValue, oldValue) {
         this._lazyContent(newValue);
-        let selectedChild = this._children[newValue];
-        this._setSelectedItem(selectedChild);
         if (newValue < --this.total) {
           this._lazyContent(++newValue);
         }

--- a/skeleton-carousel.html
+++ b/skeleton-carousel.html
@@ -381,7 +381,7 @@
             type: Object,
             notify: true,
             readOnly: true,
-            computed: '_computeSelectedItem(selected, _children)'
+            computed: '_computeSelectedItem(selected, _children)',
           },
           /**
            * The user is swiping
@@ -568,8 +568,9 @@
       /**
        * Computed the selected item
        *
-       * @param {array} children
        * @param {number} selected
+       * @param {array} children
+       * @return {object}
        * @private
        */
       _computeSelectedItem(selected, children) {


### PR DESCRIPTION
fixes #77 

The property `selectedItem` depends on `_children` and on `selected`. It should be reevaluated if one of those changes.